### PR TITLE
Change slugs to array

### DIFF
--- a/orgs/ortussolutions.json
+++ b/orgs/ortussolutions.json
@@ -9,79 +9,98 @@
             "title" : "ColdBox",
             "logo" : "https://coldbox.org/includes/img/horizontalLogo.png",
             "url" : "https://www.coldbox.org",
-            "lucee" : true,
-            "coldbox" : true,
-            "commandbox" : true
+            "engine" : "lucee",
+            "uses" : [
+                "coldbox",
+                "commandbox"
+            ]
         },
         {
             "title" : "CFCasts",
             "logo" : "https://www.cfcasts.com/includes/img/logo.svg",
             "url" : "https://www.cfcasts.com",
-            "lucee" : true,
-            "commandbox" : true,
-            "quick" : true,
-            "coldbox" : true
+            "engine" : "lucee",
+            "uses" : [
+                "commandbox",
+                "quick",
+                "coldbox"
+            ]
         },
         {
             "title" : "Commandbox",
             "logo" : "https://www.ortussolutions.com/__media/products/commandbox-white.png",
             "url" : "https://commandbox.ortusbooks.com",
-            "lucee" : true,
-            "commandbox" : true
+            "engine" : "lucee",
+            "uses" : [
+                "commandbox"
+            ]
         },
         {
             "title" : "ContentBox",
             "logo" : "https://www.contentboxcms.org/__media/contentbox-logo-white.png",
             "url" : "https://www.contentboxcms.org",
-            "lucee" : true,
-            "coldbox" : true,
-            "contentbox" : true,
-            "commandbox" : true,
-            "cborm" : true
+            "engine" : "lucee",
+            "uses" : [
+                "coldbox",
+                "contentbox",
+                "commandbox",
+                "cborm"
+            ]
         },
         {
             "title" : "IntoTheBox",
             "logo" : "https://www.intothebox.org/includes/images/2021/itb-logo.svg",
             "url" : "https://www.intothebox.org",
-            "lucee" : true,
-            "coldbox" : true,
-            "contentbox" : true,
-            "commandbox" : true,
-            "cborm" : true
+            "engine" : "lucee",
+            "uses" : [
+                "coldbox",
+                "contentbox",
+                "commandbox",
+                "cborm"
+            ]
         },
         {
             "title" : "Forgebox",
             "logo" : "https://forgebox.io/includes/images/ForgeBox150.png",
             "url" : "https://www.forgebox.io",
-            "lucee" : true,
-            "coldbox" : true,
-            "commandbox" : true,
-            "cborm" : true
+            "engine" : "lucee",
+            "uses" : [
+                "coldbox",
+                "commandbox",
+                "cborm"
+            ]
         },
         {
             "title" : "Luis F Majano",
             "url" : "https://www.luismajano.com",
-            "lucee" : true,
-            "coldbox" : true,
-            "contentbox" : true,
-            "commandbox" : true,
-            "cborm" : true
+            "engine" : "lucee",
+            "uses" : [
+                "coldbox",
+                "contentbox",
+                "commandbox",
+                "cborm"
+            ]
         },
         {
             "title" : "Ortus Books",
             "url" : "https://www.ortusbooks.com",
-            "lucee" : true,
-            "commandbox" : true
+            "engine" : "lucee",
+            "uses" : [
+                "commandbox"
+            ]
         },
         {
             "title" : "Ortus Solutions",
             "logo" : "https://www.ortussolutions.com/modules_app/contentbox-custom/_themes/ortus-2019/includes/images/static/ortus-logo-main.png",
             "url" : "https://www.ortussolutions.com",
-            "lucee" : true,
-            "coldbox" : true,
-            "contentbox" : true,
-            "commandbox" : true,
-            "cborm" : true
+            "engine" : "lucee",
+            "uses" : [
+                "coldbox",
+                "contentbox",
+                "commandbox",
+                "cborm"
+            ]
+            
         }
     ]
 }

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ Each of the sites can have the following schema
         "cborm",
         "quick",
         "commandbox"
-        // Add any other forgebox slugs you use in your project ( e.g. `quick`, `cbelasticsearch`, `cbsecurity` )
+        // Add any other forgebox slugs you use in your project ( e.g.  `cbelasticsearch`, `cbsecurity`, etc )
     ]
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ To contribute, fork and star the project.  Then add your own organization file i
     "version" : "0.0.1",
     "orgs" : [
         "ortussolutions",
-	"myorg"
+    "myorg"
     ]
 }
 ```
@@ -24,12 +24,12 @@ Then your organization can look like this: `orgs/myorg.json`
 
 ```js
 {
-	"name"       : string, // Required
-	"patreon"    : boolean, // Optional (false)
-	"description": string, // Optional
-	"url"        : URL, // Optional
-    	"logo"       : URL, // Optional
-	"sites"      : array of Sites // Optional
+    "name"       : string, // Required
+    "patreon"    : boolean, // Optional (false)
+    "description": string, // Optional
+    "url"        : URL, // Optional
+    "logo"       : URL, // Optional
+    "sites"      : array of Sites // Optional
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -42,13 +42,16 @@ Each of the sites can have the following schema
     "title" : string, //required
     "url" : URL, // required
     "logo" : URL, // optional
-    "adobe" : boolean // optional (false),
-    "lucee" : boolean // optional (false),
-    "coldbox" : boolean // optional (false),
-    "contentbox" : boolean // optional (false),
-    "quick" : boolean // optional (false),
-    "cborm" : boolean // optional (false),
-    "commandbox" : boolean // optional (false),
+    "engine" : "adobe", //optional - either `adobe` or `lucee
+    // Anything on Forgebox you use
+    "uses" : [
+        "coldbox",
+        "contentbox",
+        "cborm",
+        "quick",
+        "commandbox"
+        // Add any other forgebox slugs you use in your project ( e.g. `quick`, `cbelasticsearch`, `cbsecurity` )
+    ]
 }
 ```
 


### PR DESCRIPTION
I felt like the way we were representing everything with booleans was too limited.  This changes the dependencies to an array, and encourages the user to add anything they want from ForgeBox ( like `cbelasticsearch` :) )

It also changes the engine to a string representation, which will make it easier to filter and aggregate ( in Elasticsearch!  :) )